### PR TITLE
CI: Add workflow to build original project version

### DIFF
--- a/.github/workflows/original_android_build.yml
+++ b/.github/workflows/original_android_build.yml
@@ -1,0 +1,50 @@
+name: Original Android CI Build
+
+on:
+  push:
+    branches: [ "feat/build-original-version" ]
+  pull_request:
+    branches: [ "feat/build-original-version" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4 # Using v4 for checkout
+
+    - name: Set up JDK 8
+      uses: actions/setup-java@v4 # Using v4 for setup-java
+      with:
+        java-version: '8'
+        distribution: 'temurin' # Temurin provides JDK 8
+        cache: gradle
+
+    - name: Setup Android SDK
+      uses: android-actions/setup-android@v3 # Using v3 for setup-android
+      # This action will attempt to use the SDK versions defined in the project's original build.gradle
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Build with Gradle
+      run: ./gradlew assembleRelease
+
+    - name: List APK output files
+      run: |
+        echo "Listing app/build/outputs/apk/release:"
+        ls -R app/build/outputs/apk/release || echo "app/build/outputs/apk/release not found or empty"
+        echo "----"
+        echo "Listing app/build/outputs/apk:"
+        ls -R app/build/outputs/apk || echo "app/build/outputs/apk not found or empty"
+
+    - name: Upload APK
+      uses: actions/upload-artifact@v4 # Using v4 for upload-artifact
+      with:
+        name: original-app-release
+        # Assuming the original build might also produce an unsigned APK if not configured
+        path: app/build/outputs/apk/release/app-release-unsigned.apk
+        # Fallback or alternative path if the above is not found:
+        # path: app/build/outputs/apk/release/app-release.apk
+        if-no-files-found: warn # Important to see if the file is found


### PR DESCRIPTION
- Creates a new GitHub Actions workflow specifically for building the original version of the Android application.
- Uses JDK 8 for compatibility with the original Gradle version (4.6).
- Attempts to build 'assembleRelease' and uploads the resulting APK.
- Includes a step to list build outputs for diagnostics.